### PR TITLE
Collection convert and column length

### DIFF
--- a/jpa/general/src/java/org/datanucleus/samples/typeconversion/CollectionConverterHolder.java
+++ b/jpa/general/src/java/org/datanucleus/samples/typeconversion/CollectionConverterHolder.java
@@ -20,7 +20,7 @@ package org.datanucleus.samples.typeconversion;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.persistence.CollectionTable;
+import javax.persistence.*;
 import javax.persistence.Convert;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
@@ -38,12 +38,13 @@ public class CollectionConverterHolder
     @ElementCollection
     @CollectionTable
     @Convert(converter=MyType1StringConverter.class)
-    @javax.persistence.Column(length=1024)
+    @Column(length=1024)
     Set<MyType1> set1 = new HashSet<MyType1>();
 
     @ElementCollection
     @CollectionTable
     @Convert(converter=SetMyType1StringConverter.class)
+    @Column(length=1024)
     Set<MyType1> set2 = new HashSet<MyType1>();
 
     public CollectionConverterHolder(long id)

--- a/jpa/general/src/java/org/datanucleus/samples/typeconversion/CollectionConverterHolder.java
+++ b/jpa/general/src/java/org/datanucleus/samples/typeconversion/CollectionConverterHolder.java
@@ -38,6 +38,7 @@ public class CollectionConverterHolder
     @ElementCollection
     @CollectionTable
     @Convert(converter=MyType1StringConverter.class)
+    @javax.persistence.Column(length=1024)
     Set<MyType1> set1 = new HashSet<MyType1>();
 
     @ElementCollection

--- a/jpa/general/src/test/org/datanucleus/tests/types/AttributeConverterTest.java
+++ b/jpa/general/src/test/org/datanucleus/tests/types/AttributeConverterTest.java
@@ -1,29 +1,21 @@
 /**********************************************************************
-Copyright (c) 2012 Andy Jefferson and others. All rights reserved.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+ Copyright (c) 2012 Andy Jefferson and others. All rights reserved.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+ http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 
-Contributors:
-    ...
-**********************************************************************/
+ Contributors:
+ ...
+ **********************************************************************/
 package org.datanucleus.tests.types;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.persistence.EntityManager;
-import javax.persistence.EntityTransaction;
-import javax.persistence.Query;
 
 import org.datanucleus.samples.typeconversion.CollectionConverterHolder;
 import org.datanucleus.samples.typeconversion.ComplicatedType;
@@ -33,6 +25,14 @@ import org.datanucleus.samples.typeconversion.MyType1;
 import org.datanucleus.samples.typeconversion.MyType2;
 import org.datanucleus.samples.typeconversion.TypeHolder;
 import org.datanucleus.tests.JPAPersistenceTestCase;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+import javax.persistence.Query;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Tests for JPA 2.1 type conversion.
@@ -80,7 +80,6 @@ public class AttributeConverterTest extends JPAPersistenceTestCase
             {
                 emf.getCache().evictAll();
             }
-
             // Check the persisted info
             em = getEM();
             tx = em.getTransaction();
@@ -96,7 +95,6 @@ public class AttributeConverterTest extends JPAPersistenceTestCase
                 assertNotNull(comp2);
                 assertEquals("String 78", comp2.getName1());
                 assertEquals("Number 34", comp2.getName2());
-
                 tx.commit();
             }
             catch (Exception e)
@@ -113,20 +111,17 @@ public class AttributeConverterTest extends JPAPersistenceTestCase
                 em.close();
             }
             emf.getCache().evictAll();
-
             // Try a query using the converted type as a parameter
             em = getEM();
             tx = em.getTransaction();
             try
             {
                 tx.begin();
-
                 Query q = em.createQuery("SELECT h FROM " + TypeHolder.class.getName() + " h WHERE h.details = :value1");
                 q.setParameter("value1", new ComplicatedType("String 45", "Number 23"));
                 List<TypeHolder> results = q.getResultList();
                 assertNotNull(results);
                 assertEquals(1, results.size());
-
                 tx.commit();
             }
             catch (Exception e)
@@ -181,7 +176,6 @@ public class AttributeConverterTest extends JPAPersistenceTestCase
             {
                 emf.getCache().evictAll();
             }
-
             em = getEM();
             tx = em.getTransaction();
             try
@@ -200,7 +194,6 @@ public class AttributeConverterTest extends JPAPersistenceTestCase
                 assertNotNull(val2);
                 assertEquals("B", val2.getName1());
                 assertEquals("S", val2.getName2());
-
                 tx.commit();
             }
             catch (Exception e)
@@ -255,7 +248,6 @@ public class AttributeConverterTest extends JPAPersistenceTestCase
             {
                 emf.getCache().evictAll();
             }
-
             em = getEM();
             tx = em.getTransaction();
             try
@@ -274,7 +266,6 @@ public class AttributeConverterTest extends JPAPersistenceTestCase
                 String val2 = map.get(key2);
                 assertNotNull(val2);
                 assertEquals("Second", val2);
-
                 tx.commit();
             }
             catch (Exception e)
@@ -331,7 +322,6 @@ public class AttributeConverterTest extends JPAPersistenceTestCase
             {
                 emf.getCache().evictAll();
             }
-
             em = getEM();
             tx = em.getTransaction();
             try
@@ -357,7 +347,6 @@ public class AttributeConverterTest extends JPAPersistenceTestCase
                 }
                 assertTrue(elem1Present);
                 assertTrue(elem2Present);
-
                 Set<MyType1> set2 = p1.getSet2();
                 assertNotNull(set2);
                 assertEquals(2, set2.size());
@@ -376,7 +365,6 @@ public class AttributeConverterTest extends JPAPersistenceTestCase
                 }
                 assertTrue(elem3Present);
                 assertTrue(elem4Present);
-
                 tx.commit();
             }
             catch (Exception e)
@@ -391,6 +379,110 @@ public class AttributeConverterTest extends JPAPersistenceTestCase
                     tx.rollback();
                 }
                 em.close();
+            }
+        }
+        finally
+        {
+            clean(CollectionConverterHolder.class);
+        }
+    }
+
+    public void testConverterLength()
+    {
+        try
+        {
+            EntityManager em = getEM();
+            EntityTransaction tx = em.getTransaction();
+            try
+            {
+                tx.begin();
+                CollectionConverterHolder h = new CollectionConverterHolder(1);
+                byte[] tmp = new byte[2048];//more than 1024
+                Arrays.fill(tmp, (byte) 48);
+                h.getSet1().add(new MyType1("TooLong", new String(tmp)));
+                em.persist(h);
+                tx.commit();
+            }
+            catch (Exception e)
+            {
+                LOG.error(">> Exception thrown during persist when using type converter", e);
+                assertTrue(e.getMessage(),
+                           e.getMessage().indexOf("\"SET1_ELEMENT\" that has maximum length of 1024") > 0);
+                //                fail("Failure on persist with type converter : " + e.getMessage());
+            }
+            finally
+            {
+                if (tx.isActive())
+                {
+                    tx.rollback();
+                }
+                em.close();
+            }
+            if (emf.getCache() != null)
+            {
+                emf.getCache().evictAll();
+            }
+            em = getEM();
+            tx = em.getTransaction();
+            try
+            {
+                tx.begin();
+                CollectionConverterHolder h = new CollectionConverterHolder(1);
+                byte[] tmp = new byte[2048];//more than 1024
+                Arrays.fill(tmp, (byte) 48);
+                h.getSet2().add(new MyType1("TooLong", new String(tmp)));
+                em.persist(h);
+                tx.commit();
+            }
+            catch (Exception e)
+            {
+                LOG.error(">> Exception thrown during persist when using type converter", e);
+                assertTrue(e.getMessage(),
+                           e.getMessage().indexOf("\"SET1_ELEMENT\" that has maximum length of 1024") > 0);
+                //                fail("Failure on persist with type converter : " + e.getMessage());
+            }
+            finally
+            {
+                if (tx.isActive())
+                {
+                    tx.rollback();
+                }
+                em.close();
+            }
+            if (emf.getCache() != null)
+            {
+                emf.getCache().evictAll();
+            }
+            em = getEM();
+            tx = em.getTransaction();
+            try
+            {
+                tx.begin();
+                CollectionConverterHolder h = new CollectionConverterHolder(2);
+                byte[] tmp = new byte[255];
+                Arrays.fill(tmp, (byte) 48);
+                //more than 255 and less than 1024
+                h.getSet1().add(new MyType1("Long1", new String(tmp)));
+                h.getSet1().add(new MyType1("Long2", new String(tmp)));
+                em.persist(h);
+                tx.commit();
+            }
+            catch (Exception e)
+            {
+                LOG.error(">> Exception thrown during persist when using type converter", e);
+                fail("Failure on persist with type converter : " + e.getMessage());
+            }
+            finally
+            {
+                if (tx.isActive())
+                {
+                    tx.rollback();
+                }
+                em.close();
+            }
+            if (emf.getCache() != null)
+            {
+                emf.getCache().evictAll();
             }
         }
         finally

--- a/jpa/general/src/test/org/datanucleus/tests/types/AttributeConverterTest.java
+++ b/jpa/general/src/test/org/datanucleus/tests/types/AttributeConverterTest.java
@@ -437,8 +437,8 @@ public class AttributeConverterTest extends JPAPersistenceTestCase
             catch (Exception e)
             {
                 LOG.error(">> Exception thrown during persist when using type converter", e);
-                assertTrue(e.getMessage(),
-                           e.getMessage().indexOf("\"SET1_ELEMENT\" that has maximum length of 1024") > 0);
+                assertFalse(e.getMessage(),
+                           e.getMessage().indexOf("\"SET2\" that has maximum length of 255") > 0);
                 //                fail("Failure on persist with type converter : " + e.getMessage());
             }
             finally


### PR DESCRIPTION
I added  @Column(length=1024) on fields.

Using MyType1StringConverter, it works fine.
Using a collection converter SetMyType1StringConverter, it doesn't work.

the test method testConverterLength is added at the end of AttributeConverterTest.
