### PR TITLE
Improvements to ExecutionContext.findObject and Level 1 cache handling.

### DIFF
--- a/jdo/rdbms/src/resources/META-INF/MANIFEST.MF
+++ b/jdo/rdbms/src/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: myplugin
+Bundle-SymbolicName: jdo-rdbms-test
+Bundle-Version: 1.0.0
+Bundle-Vendor: Data Nucleus Test

--- a/jdo/rdbms/src/resources/plugin.xml
+++ b/jdo/rdbms/src/resources/plugin.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<plugin id="org.datanucleus.jdo-rdbms-tests" name="DataNucleus JDO RDBMS Tests" provider-name="DataNucleus">
+    <extension point="org.datanucleus.store_manager">
+        <store-manager class-name="org.datanucleus.tests.findobject.FindObjectTestStoreManager" url-key="findobject_rdbmsjdbc" key="findobject_rdbms" priority="1"/>
+    </extension>
+</plugin>

--- a/jdo/rdbms/src/test/org/datanucleus/tests/findobject/FindObjectTest.java
+++ b/jdo/rdbms/src/test/org/datanucleus/tests/findobject/FindObjectTest.java
@@ -1,0 +1,420 @@
+package org.datanucleus.tests.findobject;
+
+import org.datanucleus.ExecutionContext;
+import org.datanucleus.PropertyNames;
+import org.datanucleus.api.jdo.JDOPersistenceManager;
+import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+import org.datanucleus.enhancement.Persistable;
+import org.datanucleus.management.ManagerStatistics;
+import org.datanucleus.samples.models.transportation.Address;
+import org.datanucleus.state.DNStateManager;
+import org.datanucleus.state.LifeCycleState;
+import org.datanucleus.store.rdbms.RDBMSStoreManager;
+import org.datanucleus.tests.JDOPersistenceTestCase;
+import org.datanucleus.tests.TestHelper;
+import org.junit.Assume;
+
+import javax.jdo.PersistenceManager;
+import javax.jdo.PersistenceManagerFactory;
+import javax.jdo.Query;
+import javax.jdo.Transaction;
+import java.util.List;
+import java.util.Properties;
+
+public class FindObjectTest extends JDOPersistenceTestCase
+{
+    /**
+     * Test find object from standard persistence handler in store manager
+     */
+    public void testFindObjectFromStandardPersistenceHandler()
+    {
+        Properties userProps = new Properties();
+        userProps.put("javax.jdo.option.Optimistic", "true");
+        userProps.setProperty(PropertyNames.PROPERTY_ENABLE_STATISTICS, "true");
+
+        final int testNumber = 1;
+        PersistenceManagerFactory pmfForTest = getPMF(testNumber, userProps);
+
+        if (!(((JDOPersistenceManagerFactory)pmfForTest).getNucleusContext().getStoreManager() instanceof RDBMSStoreManager))
+        {
+            return;
+        }
+
+        try
+        {
+            PersistenceManager pm = pmfForTest.getPersistenceManager();
+            final Transaction tx = pm.currentTransaction();
+            try
+            {
+                tx.begin();
+
+                int no = 0;
+                final Address pc = new Address(no++);
+                pc.setAddressLine("1313 Webfoot Walk");
+                pm.makePersistent(pc);
+                final Object oid = ((Persistable)pc).dnGetObjectId();
+                tx.commit();
+                tx.begin();
+
+                final ExecutionContext ec = ((JDOPersistenceManager) pm).getExecutionContext();
+                final ManagerStatistics statistics = ec.getStatistics();
+
+                int readsBefore = getTotalReads(statistics);
+
+                // find from L1 cache - no validate
+                final Persistable o1 = ec.findObject(oid, false, false, pc.getClass().getName());
+                int readsNow = getTotalReads(statistics);
+                assertTrue("Should be same PC instance returned from findObject", pc == o1);
+                assertEquals("No reads expected reading from L1 cache - and no validate", readsBefore, readsNow);
+
+                // find from L1 cache - with validate
+                final Persistable o2 = ec.findObject(oid, true, false, pc.getClass().getName());
+                assertTrue("Should be same PC instance returned from findObject", pc == o2);
+                assertNotHollow(o2);
+
+                readsNow = getTotalReads(statistics);
+                assertEquals("Validate read expected reading from L1 cache - due to validate DB check", readsBefore+1, readsNow);
+                readsBefore = readsNow;
+
+                // test where nothing in L1 and L2 cache
+                clearCaches(pm);
+                final Persistable o3 = ec.findObject(oid, true, false, pc.getClass().getName());
+                readsNow = getTotalReads(statistics);
+                assertNotHollow(o3);
+
+                assertTrue("Validate read expected reading from L1 cache - due to load from DB", readsBefore < readsNow);
+                readsBefore = getTotalReads(statistics);
+
+                pm.deletePersistent(pc);
+                tx.commit();
+
+            }
+            finally
+            {
+                if (tx.isActive())
+                {
+                    tx.rollback();
+                }
+                pm.close();
+            }
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+            LOG.error(e);
+            fail("Exception thrown while performing lock-manager test : " + e.getMessage());
+        }
+        finally
+        {
+            // Clean out our data
+            clean(pmfForTest, Address.class);
+        }
+    }
+
+    /**
+     * Test find object from persistence handler in custom persistence handler supporting findObject
+     */
+    public void testFindObjectFromCustomPersistenceHandler()
+    {
+        Properties userProps = new Properties();
+        userProps.put("javax.jdo.option.Optimistic", "true");
+        userProps.setProperty(PropertyNames.PROPERTY_ENABLE_STATISTICS, "true");
+
+        final int testNumber = 1;
+        final Properties factoryProperties = TestHelper.getFactoryProperties(testNumber, userProps);
+        String dnConnectionurl = FindObjectTestStoreManager.DN_CONNECTIONURL;
+        Object url = factoryProperties.get(dnConnectionurl);
+        if (url == null)
+        {
+            dnConnectionurl = dnConnectionurl.toLowerCase();
+            factoryProperties.get(dnConnectionurl);
+        }
+        Assume.assumeTrue(url instanceof String && ((String)url).startsWith("jdbc"));
+        userProps.setProperty(dnConnectionurl, FindObjectTestStoreManager.STOREMANAGER_PREFIX+url);
+        PersistenceManagerFactory pmfForTest = getPMF(testNumber, userProps);
+
+        if (!(((JDOPersistenceManagerFactory)pmfForTest).getNucleusContext().getStoreManager() instanceof RDBMSStoreManager))
+        {
+            return;
+        }
+
+        try
+        {
+            PersistenceManager pm = pmfForTest.getPersistenceManager();
+            final Transaction tx = pm.currentTransaction();
+            try
+            {
+                tx.begin();
+
+                int no = 0;
+                final Address pc = new Address(no++);
+                pc.setAddressLine("1313 Webfoot Walk");
+                pm.makePersistent(pc);
+                final Object oid = ((Persistable)pc).dnGetObjectId();
+                tx.commit();
+                tx.begin();
+
+                final ExecutionContext ec = ((JDOPersistenceManager) pm).getExecutionContext();
+                final ManagerStatistics statistics = ec.getStatistics();
+
+                int readsBefore = getTotalReads(statistics);
+
+                // find from L1 cache - no validate
+                final Persistable o1 = ec.findObject(oid, false, false, pc.getClass().getName());
+                int readsNow = getTotalReads(statistics);
+                assertTrue("Should be same PC instance returned from findObject", pc == o1);
+                assertEquals("No reads expected reading from L1 cache - and no validate", readsBefore, readsNow);
+
+                // find from L1 cache - with validate
+                final Persistable o2 = ec.findObject(oid, true, false, pc.getClass().getName());
+                assertTrue("Should be same PC instance returned from findObject", pc == o2);
+                assertNotHollow(o1);
+
+                readsNow = getTotalReads(statistics);
+                assertEquals("Validate read expected reading from L1 cache - due to validate DB check", readsBefore+1, readsNow);
+                readsBefore = readsNow;
+
+                // test where nothing in L1 and L2 cache - but PersistenceHandler is able to provide object
+                ((FindObjectTestPersistenceHandler)ec.getStoreManager().getPersistenceHandler()).setNextFindObject((Address) o2);
+                clearCaches(pm);
+                final Persistable o3 = ec.findObject(oid, true, false, pc.getClass().getName());
+                readsNow = getTotalReads(statistics);
+                assertNotHollow(o3);
+
+                assertEquals("Validate read NOT expected as read from persistence handler - no need to validate in DB again", readsBefore, readsNow);
+                readsBefore = getTotalReads(statistics);
+
+                pm.deletePersistent(pc);
+                tx.commit();
+
+            }
+            finally
+            {
+                if (tx.isActive())
+                {
+                    tx.rollback();
+                }
+                pm.close();
+            }
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+            LOG.error(e);
+            fail("Exception thrown while performing lock-manager test : " + e.getMessage());
+        }
+        finally
+        {
+            // Clean out our data
+            clean(pmfForTest, Address.class);
+        }
+    }
+
+    /**
+     * Test find object used for instance in JDOQuery - ignoring cache
+     */
+    public void testFindObjectUsedFromJDOQuery()
+    {
+        Properties userProps = new Properties();
+        userProps.put("javax.jdo.option.Optimistic", "true");
+        userProps.setProperty(PropertyNames.PROPERTY_ENABLE_STATISTICS, "true");
+
+        final int testNumber = 1;
+        PersistenceManagerFactory pmfForTest = getPMF(testNumber, userProps);
+
+        if (!(((JDOPersistenceManagerFactory)pmfForTest).getNucleusContext().getStoreManager() instanceof RDBMSStoreManager))
+        {
+            return;
+        }
+
+        try
+        {
+            PersistenceManager pm = pmfForTest.getPersistenceManager();
+            final Transaction tx = pm.currentTransaction();
+            try
+            {
+                tx.begin();
+
+                int no = 0;
+                final Address pc = new Address(no++);
+                pc.setAddressLine("1313 Webfoot Walk");
+                pm.makePersistent(pc);
+                pm.flush();
+
+                // test JDO query finds same instance - so that we dont end up with two PC instances for same instance
+                {
+                    Object res = pm.newQuery(Address.class)
+                            .filter("id==:theid")
+                            .executeWithArray(no - 1);
+                    Address foundAddress = ((List<Address>) res).get(0);
+                    assertEquals("Expects to find same instance", pc, foundAddress);
+                }
+
+                // test JDO query finds same instance - so that we dont end up with two PC instances for same instance
+                // Even if we ignore cache this must not happen
+                {
+                    final Query<Address> query = pm.newQuery(Address.class)
+                            .filter("id==:theid");
+                    query.setIgnoreCache(true);
+                    Object res = query.executeWithArray(no - 1);
+                    Address foundAddress = ((List<Address>) res).get(0);
+                    assertEquals("Expects to find same instance", pc, foundAddress);
+                }
+
+                pm.deletePersistent(pc);
+                tx.commit();
+
+            }
+            finally
+            {
+                if (tx.isActive())
+                {
+                    tx.rollback();
+                }
+                pm.close();
+            }
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+            LOG.error(e);
+            fail("Exception thrown while performing lock-manager test : " + e.getMessage());
+        }
+        finally
+        {
+            // Clean out our data
+            clean(pmfForTest, Address.class);
+        }
+    }
+
+    /**
+     * Test find object used for instance in JDOQuery - ignoring cache
+     */
+    public void testFindObjectUsedFromJDOQueryCallingPersistenceHandler()
+    {
+        Properties userProps = new Properties();
+        userProps.put("javax.jdo.option.Optimistic", "true");
+        userProps.setProperty(PropertyNames.PROPERTY_ENABLE_STATISTICS, "true");
+
+        final int testNumber = 1;
+        final Properties factoryProperties = TestHelper.getFactoryProperties(testNumber, userProps);
+        String dnConnectionurl = FindObjectTestStoreManager.DN_CONNECTIONURL;
+        Object url = factoryProperties.get(dnConnectionurl);
+        if (url == null)
+        {
+            dnConnectionurl = dnConnectionurl.toLowerCase();
+            factoryProperties.get(dnConnectionurl);
+        }
+        Assume.assumeTrue(url instanceof String && ((String)url).startsWith("jdbc"));
+        userProps.setProperty(dnConnectionurl, FindObjectTestStoreManager.STOREMANAGER_PREFIX+url);
+        PersistenceManagerFactory pmfForTest = getPMF(testNumber, userProps);
+
+        if (!(((JDOPersistenceManagerFactory)pmfForTest).getNucleusContext().getStoreManager() instanceof RDBMSStoreManager))
+        {
+            return;
+        }
+
+        try
+        {
+            PersistenceManager pm = pmfForTest.getPersistenceManager();
+            final Transaction tx = pm.currentTransaction();
+            try
+            {
+                tx.begin();
+
+                int no = 0;
+                final Address pc = new Address(no++);
+                pc.setAddressLine("1313 Webfoot Walk");
+                pm.makePersistent(pc);
+                tx.commit();
+                tx.begin();
+
+                final String addressString = getAddressString(pc);
+
+                clearCaches(pm); // clear both L1 and L2 cache
+                final ExecutionContext ec = ((JDOPersistenceManager) pm).getExecutionContext();
+                final FindObjectTestPersistenceHandler persistenceHandler = (FindObjectTestPersistenceHandler)ec.getStoreManager().getPersistenceHandler();
+
+                int callCountBefore = persistenceHandler.getCallCount();
+                // Test JDO query finds equivalent instance (not same as L1 cache is cleared)
+                // AND that is do not call PersistenceHandler when it has all values from FieldValues
+                {
+                    Object res = pm.newQuery(Address.class)
+                            .filter("id==:theid")
+                            .executeWithArray(no - 1);
+                    Address foundAddress = ((List<Address>) res).get(0);
+                    assertEquals("Expects to find same content", addressString, getAddressString(foundAddress));
+                }
+
+                // Test JDO query finds equivalent instance (not same as L1 cache is cleared)
+                // AND that is do not call PersistenceHandler when it has all values from FieldValues
+                // Even if we ignore cache this must not happen
+                clearCaches(pm); // clear both L1 and L2 cache
+                {
+                    final Query<Address> query = pm.newQuery(Address.class)
+                            .filter("id==:theid");
+                    query.setIgnoreCache(true);
+                    Object res = query.executeWithArray(no - 1);
+                    Address foundAddress = ((List<Address>) res).get(0);
+                    assertEquals("Expects to find same content", addressString, getAddressString(foundAddress));
+                }
+                int callCountAfter = persistenceHandler.getCallCount();
+                assertEquals("Persistence handler not expected to be called when FieldValues are used for finding object", callCountBefore, callCountAfter);
+
+                pm.deletePersistent(pc);
+                tx.commit();
+
+            }
+            finally
+            {
+                if (tx.isActive())
+                {
+                    tx.rollback();
+                }
+                pm.close();
+            }
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+            LOG.error(e);
+            fail("Exception thrown while performing lock-manager test : " + e.getMessage());
+        }
+        finally
+        {
+            // Clean out our data
+            clean(pmfForTest, Address.class);
+        }
+    }
+
+    private void assertNotHollow(Persistable o3)
+    {
+        assertFalse("Object should not be hollow - after findObject with validate which triggers a read which in turn transitions to NonTransactional)", isHollow(o3));
+    }
+
+    private boolean isHollow(Persistable o1)
+    {
+        final LifeCycleState lifecycleState = ((DNStateManager) o1.dnGetStateManager()).getLifecycleState();
+        return LifeCycleState.HOLLOW == lifecycleState.stateType();
+    }
+
+    private static int getTotalReads(ManagerStatistics statistics)
+    {
+        return statistics.getNumberOfDatastoreReads();
+    }
+
+    private String getAddressString(Address address)
+    {
+        return address == null ? "<null>" :
+                address.getClass().getSimpleName() + "{" +
+                        "; addressLine=" + address.getAddressLine() +
+                        "; type=" + address.getType() +
+                        "}";
+    }
+
+    private void clearCaches(PersistenceManager pm)
+    {
+        pm.evictAll();
+        pm.getPersistenceManagerFactory().getDataStoreCache().evictAll();
+    }
+}

--- a/jdo/rdbms/src/test/org/datanucleus/tests/findobject/FindObjectTestPersistenceHandler.java
+++ b/jdo/rdbms/src/test/org/datanucleus/tests/findobject/FindObjectTestPersistenceHandler.java
@@ -1,0 +1,58 @@
+package org.datanucleus.tests.findobject;
+
+import org.datanucleus.ExecutionContext;
+import org.datanucleus.samples.models.transportation.Address;
+import org.datanucleus.state.DNStateManager;
+import org.datanucleus.store.StoreManager;
+import org.datanucleus.store.ValidatingStorePersistenceHandler;
+import org.datanucleus.store.rdbms.RDBMSPersistenceHandler;
+
+public class FindObjectTestPersistenceHandler extends RDBMSPersistenceHandler implements ValidatingStorePersistenceHandler
+{
+    private String nextFindObjectAddressLine;
+    private int callCount=0;
+    /**
+     * Constructor.
+     *
+     * @param storeMgr StoreManager
+     */
+    public FindObjectTestPersistenceHandler(StoreManager storeMgr)
+    {
+        super(storeMgr);
+    }
+
+    @Override
+    public Object findObject(ExecutionContext ec, Object id)
+    {
+        callCount++;
+        if (nextFindObjectAddressLine != null) {
+            final DNStateManager<Address> sm = storeMgr.getNucleusContext().getStateManagerFactory().newForHollow(ec, Address.class, id);
+            final int addressLineFieldNo = sm.getClassMetaData().getAbsolutePositionOfMember("addressLine");
+            sm.replaceField(addressLineFieldNo, nextFindObjectAddressLine);
+            sm.isLoaded(addressLineFieldNo);
+            nextFindObjectAddressLine = null;
+            return sm.getObject();
+        }
+        return super.findObject(ec, id);
+    }
+
+    public int getCallCount()
+    {
+        return callCount;
+    }
+
+    public void setNextFindObject(Address o)
+    {
+        nextFindObjectAddressLine = o.getAddressLine();
+    }
+
+    @Override
+    public void validate(DNStateManager sm, boolean readFromPersistenceHandler)
+    {
+        if (readFromPersistenceHandler)
+        {
+            return;
+        }
+        sm.validate();
+    }
+}

--- a/jdo/rdbms/src/test/org/datanucleus/tests/findobject/FindObjectTestStoreManager.java
+++ b/jdo/rdbms/src/test/org/datanucleus/tests/findobject/FindObjectTestStoreManager.java
@@ -1,0 +1,50 @@
+package org.datanucleus.tests.findobject;
+
+import org.datanucleus.ClassLoaderResolver;
+import org.datanucleus.PersistenceNucleusContext;
+import org.datanucleus.store.rdbms.RDBMSPersistenceHandler;
+import org.datanucleus.store.rdbms.RDBMSStoreManager;
+
+import java.util.Map;
+
+public class FindObjectTestStoreManager extends RDBMSStoreManager
+{
+    public static final String DN_CONNECTIONURL = "datanucleus.ConnectionURL";
+    public static final String STOREMANAGER_PREFIX = "findobject_rdbms";
+
+    /**
+     * Constructs a new RDBMSManager.
+     * On successful return the new RDBMSManager will have successfully connected to the database with the given
+     * credentials and determined the schema name, but will not have inspected the schema contents any further.
+     * The contents (tables, views, etc.) will be subsequently created and/or validated on-demand as the application
+     * accesses persistent classes.
+     *
+     * @param clr   the ClassLoaderResolver
+     * @param ctx   The corresponding Context. This factory's non-tx data source will be used to get database connections as needed to perform management functions.
+     * @param props Properties for the datastore
+     * @throws NucleusDataStoreException If the database could not be accessed or the name of the schema could not be determined.
+     */
+    public FindObjectTestStoreManager(ClassLoaderResolver clr, PersistenceNucleusContext ctx, Map<String, Object> props)
+    {
+        super(clr, ctx, fixProps(props));
+    }
+
+    private static Map<String, Object> fixProps(Map<String, Object> props)
+    {
+        String dnConnectionurl = DN_CONNECTIONURL;
+        String url = (String) props.get(dnConnectionurl);
+        if (url == null)
+        {
+            dnConnectionurl = dnConnectionurl.toLowerCase();
+            url = (String) props.get(dnConnectionurl);
+        }
+        props.put(dnConnectionurl, url.substring(STOREMANAGER_PREFIX.length()));
+        return props;
+    }
+
+    @Override
+    protected RDBMSPersistenceHandler createPersistenceHandler()
+    {
+        return new FindObjectTestPersistenceHandler(this);
+    }
+}


### PR DESCRIPTION
Improved ExecutionContext.findObject to not return duplicate PC instances of already existing PC in Level 1 cache. Also improved ExecutionContext.findObject to not call PersistenceHandler.findObject if FieldValues is supplied with all the data. And enabled PersistenceHandler to avoid doing extra DB validate check if already found object from DB. And added custom Level 1 cache performance optimization.